### PR TITLE
Fix issue with "item" for collection of objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,6 @@
             "email": "mail@andreass.net"
         }
     ],
-    "repositories" : [
-    	{
-            "type" : "vcs",
-            "url" : "https://github.com/raziel057/BeSimpleSoapBundle"
-        }
-    ],
     "require": {
         "php": ">=5.3.0",
         "ext-soap": "*",

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,12 @@
             "email": "mail@andreass.net"
         }
     ],
-    "repositories" : [{
-			"type" : "vcs",
-			"url" : "https://github.com/raziel057/BeSimpleSoapBundle"
-		}
-	],
+    "repositories" : [
+    	{
+            "type" : "vcs",
+            "url" : "https://github.com/raziel057/BeSimpleSoapBundle"
+        }
+    ],
     "require": {
         "php": ">=5.3.0",
         "ext-soap": "*",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
             "email": "mail@andreass.net"
         }
     ],
+    "repositories" : [{
+			"type" : "vcs",
+			"url" : "https://github.com/raziel057/BeSimpleSoapBundle"
+		}
+	],
     "require": {
         "php": ">=5.3.0",
         "ext-soap": "*",

--- a/src/BeSimple/SoapBundle/ServiceBinding/RpcLiteralResponseMessageBinder.php
+++ b/src/BeSimple/SoapBundle/ServiceBinding/RpcLiteralResponseMessageBinder.php
@@ -68,7 +68,14 @@ class RpcLiteralResponseMessageBinder implements MessageBinderInterface
 
                 $message = $array;
             } else {
-                $message = $this->checkComplexType($phpType, $message);
+                if (is_array($message)) {
+                    foreach ($message as $complexType) {
+                        $array[] = $this->checkComplexType($phpType, $complexType);
+                    }
+                    $message = $array;
+                } else {
+                    $message = $this->checkComplexType($phpType, $message);
+                }
             }
         }
 

--- a/src/BeSimple/SoapBundle/ServiceDefinition/Annotation/ComplexType.php
+++ b/src/BeSimple/SoapBundle/ServiceDefinition/Annotation/ComplexType.php
@@ -18,6 +18,8 @@ class ComplexType extends Configuration
     private $name;
     private $value;
     private $isNillable = false;
+    private $minOccurs;
+    private $maxOccurs;
 
     public function getName()
     {
@@ -47,6 +49,26 @@ class ComplexType extends Configuration
     public function setNillable($isNillable)
     {
         $this->isNillable = (bool) $isNillable;
+    }
+
+    public function getMinOccurs()
+    {
+        return $this->minOccurs;
+    }
+
+    public function setMinOccurs($minOccurs)
+    {
+        $this->minOccurs = $minOccurs;
+    }
+
+    public function getMaxOccurs()
+    {
+        return $this->maxOccurs;
+    }
+
+    public function setMaxOccurs($maxOccurs)
+    {
+        $this->maxOccurs = $maxOccurs;
     }
 
     public function getAliasName()

--- a/src/BeSimple/SoapBundle/ServiceDefinition/ComplexType.php
+++ b/src/BeSimple/SoapBundle/ServiceDefinition/ComplexType.php
@@ -20,6 +20,8 @@ class ComplexType
     private $name;
     private $value;
     private $isNillable = false;
+    private $minOccurs;
+    private $maxOccurs;
 
     public function getName()
     {
@@ -49,5 +51,24 @@ class ComplexType
     public function setNillable($isNillable)
     {
         $this->isNillable = (bool) $isNillable;
+    }
+
+    public function getMinOccurs()
+    {
+        return $this->minOccurs;
+    }
+
+    public function setMinOccurs($minOccurs)
+    {
+        $this->minOccurs = $minOccurs;
+    }
+    public function getMaxOccurs()
+    {
+        return $this->maxOccurs;
+    }
+
+    public function setMaxOccurs($maxOccurs)
+    {
+        $this->maxOccurs = $maxOccurs;
     }
 }

--- a/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationClassLoader.php
+++ b/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationClassLoader.php
@@ -155,7 +155,7 @@ class AnnotationClassLoader extends Loader
             $loaded = $complexTypeResolver->load($phpType);
             $complexType = new ComplexType($phpType, isset($loaded['alias']) ? $loaded['alias'] : $phpType);
             foreach ($loaded['properties'] as $name => $property) {
-                $complexType->add($name, $this->loadType($property->getValue()), $property->isNillable());
+                $complexType->add($name, $this->loadType($property->getValue()), $property->isNillable(), $property->getMinOccurs(), $property->getMaxOccurs());
             }
 
             $this->typeRepository->addComplexType($complexType);

--- a/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationComplexTypeLoader.php
+++ b/src/BeSimple/SoapBundle/ServiceDefinition/Loader/AnnotationComplexTypeLoader.php
@@ -58,6 +58,8 @@ class AnnotationComplexTypeLoader extends AnnotationClassLoader
                 $propertyComplexType = new ComplexType();
                 $propertyComplexType->setValue($complexType->getValue());
                 $propertyComplexType->setNillable($complexType->isNillable());
+                $propertyComplexType->setMinOccurs($complexType->getMinOccurs());
+                $propertyComplexType->setMaxOccurs($complexType->getMaxOccurs());
                 $propertyComplexType->setName($property->getName());
                 $annotations['properties']->add($propertyComplexType);
             }

--- a/src/BeSimple/SoapCommon/Definition/Message.php
+++ b/src/BeSimple/SoapCommon/Definition/Message.php
@@ -48,13 +48,13 @@ class Message
         return 0 === count($this->parts) ? true : false;
     }
 
-    public function add($name, $phpType, $nillable = false)
+    public function add($name, $phpType, $nillable = false, $minOccurs = null, $maxOccurs = null)
     {
         if ($phpType instanceof TypeInterface) {
             $phpType = $phpType->getPhpType();
         }
 
-        $this->parts[$name] = new Part($name, $phpType, $nillable);
+        $this->parts[$name] = new Part($name, $phpType, $nillable, $minOccurs, $maxOccurs);
 
         return $this;
     }

--- a/src/BeSimple/SoapCommon/Definition/Part.php
+++ b/src/BeSimple/SoapCommon/Definition/Part.php
@@ -56,20 +56,22 @@ class Part
     {
         $this->nillable = (boolean) $nillable;
     }
-    
+
     public function getMinOccurs()
     {
         return $this->minOccurs;
     }
-    
+
     public function setMinOccurs($minOccurs)
     {
         $this->minOccurs = $minOccurs;
     }
+
     public function getMaxOccurs()
     {
         return $this->maxOccurs;
     }
+
     public function setMaxOccurs($maxOccurs)
     {
         $this->maxOccurs = $maxOccurs;

--- a/src/BeSimple/SoapCommon/Definition/Part.php
+++ b/src/BeSimple/SoapCommon/Definition/Part.php
@@ -20,12 +20,16 @@ class Part
     protected $name;
     protected $type;
     protected $nillable;
+    protected $minOccurs;
+    protected $maxOccurs;
 
-    public function __construct($name, $type, $nillable = false)
+    public function __construct($name, $type, $nillable = false, $minOccurs = null, $maxOccurs = null)
     {
         $this->name = $name;
         $this->type = $type;
         $this->setNillable($nillable);
+        $this->setMinOccurs($minOccurs);
+        $this->setNillable($maxOccurs);
     }
 
     public function getName()
@@ -51,5 +55,23 @@ class Part
     public function setNillable($nillable)
     {
         $this->nillable = (boolean) $nillable;
+    }
+    
+    public function getMinOccurs()
+    {
+        return $this->minOccurs;
+    }
+    
+    public function setMinOccurs($minOccurs)
+    {
+        $this->minOccurs = $minOccurs;
+    }
+    public function getMaxOccurs()
+    {
+        return $this->maxOccurs;
+    }
+    public function setMaxOccurs($maxOccurs)
+    {
+        $this->maxOccurs = $maxOccurs;
     }
 }

--- a/src/BeSimple/SoapWsdl/Dumper/Dumper.php
+++ b/src/BeSimple/SoapWsdl/Dumper/Dumper.php
@@ -259,6 +259,13 @@ class Dumper
             if ($child->isNillable()) {
                 $element->setAttribute('nillable', 'true');
             }
+            
+            if (null !== $child->getMinOccurs() && 1 != $child->getMinOccurs()) {
+                $element->setAttribute('minOccurs', $child->getMinOccurs());
+            }
+            if (null !== $child->getMaxOccurs() && 1 != $child->getMaxOccurs()) {
+                $element->setAttribute('maxOccurs', $child->getMaxOccurs());
+            }
 
             if ($type instanceof ArrayOfType) {
                 $element->setAttribute('minOccurs', 0);


### PR DESCRIPTION
The goal of this PR is to fix the problem described here :
https://github.com/BeSimple/BeSimpleSoap/issues/48

With this PR it's possible to define a collection of object like this:

``` php
/**
 * @Soap\Alias("ParticipantTypeDetail")
 */
class ParticipantTypeDetail
{
    /**
     * @var string
     * @Soap\ComplexType("string")
     */
    private $name;

    /**
     * @var ParticipantTypeProperty[]
     * @Soap\ComplexType("PTC\WsBundle\TO\ParticipantProperty", minOccurs="1", maxOccurs="unbounded")
     */
    private $participantList;
```

The related generated WSDL is:

```
<xsd:complexType name="ParticipantTypeDetail">
    <xsd:all>
        <xsd:element name="name" type="xsd:string"/>
        <xsd:element name="participantList" type="tns:ParticipantProperty" minOccurs="1" maxOccurs="unbounded"/>
    </xsd:all>
</xsd:complexType>
```

Sample of response from a WS Call:

```
<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://organisation.novento-reloaded.eu/ws/MobileApi/1.0/">
   <SOAP-ENV:Body>
      <ns1:getParticipantTypeDetailsResponse>
         <return>
            <name>Supplier</name>
            <participantList>
               <id>12</id>
               <firstName>Thomas</firstName>
               <lastName>Lallement</lastName>
               <organisation>Decostanding</organisation>
               <position>Driver</position>
               <participationStatusClass>accredited</participationStatusClass>
            </participantList>
            <participantList>
               <id>22</id>
               <firstName>Jerome</firstName>
               <lastName>Martin</lastName>
               <organisation>Decostanding</organisation>
               <position>Fire departement</position>
               <participationStatusClass>requested</participationStatusClass>
            </participantList>
         </return>
      </ns1:getParticipantTypeDetailsResponse>
   </SOAP-ENV:Body>
</SOAP-ENV:Envelope>
```

So from the client side we can fetch the results by doing (sample with PHP Classmap)

``` php
$participantList = $myObject->getParticipantList();
```

Rather than (current behavior):

``` php
$participantList = $myObject->getParticipantList()->item;
```
